### PR TITLE
Fix typo in the README + update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # New Instance Creator
-The New Instance Creator (you can call him Nicolas!) is a tool used alongside the [Theos](https://theos.dev/docs/) build system to generate the boilerplate for a project or subproject. It cna ask questions so it can pre-fill certain details such as the project name. NIC templates are tar archives with a certain structure that NIC can understand. NIC was once integrated in the same Git repo as Theos, but now has been decoupled from Theos to its own repo.
+The New Instance Creator (you can call him Nicolas!) is a tool used alongside the [Theos](https://theos.dev/docs/) build system to generate the boilerplate for a project or subproject. It can ask questions to help you fill in certain details such as the project name. NIC templates are tar archives with a certain structure that NIC can understand. NIC was once integrated in the same Git repo as Theos, but now has been decoupled from Theos to its own repo.
 
 Documentation is available on the [NIC page](https://theos.dev/docs/nic) of [theos.dev](https://theos.dev/docs/).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # New Instance Creator
-The New Instance Creator (you can call him Nicolas!) is a tool used alongside the [Theos](https://theos.github.io/) build system to generate the boilerplate for a project or subproject. It cna ask questions so it can pre-fill certain details such as the project name. NIC templates are tar archives with a certain structure that NIC can understand. NIC was once integrated in the same Git repo as Theos, but now has been decoupled from Theos to its own repo.
+The New Instance Creator (you can call him Nicolas!) is a tool used alongside the [Theos](https://theos.dev/docs/) build system to generate the boilerplate for a project or subproject. It cna ask questions so it can pre-fill certain details such as the project name. NIC templates are tar archives with a certain structure that NIC can understand. NIC was once integrated in the same Git repo as Theos, but now has been decoupled from Theos to its own repo.
 
-Documentation is available on the [NIC page](http://iphonedevwiki.net/index.php/NIC) of iPhone Dev Wiki. 
+Documentation is available on the [NIC page](https://theos.dev/docs/nic) of [theos.dev](https://theos.dev/docs/).
 
 ## License
 Licensed under the GNU General Public License, version 3.0, with an exception that projects created using NIC are not required to use the same license. Refer to [LICENSE.md](LICENSE.md).


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes a typo in the README and updates the links to point to theos.dev/docs

Does this close any currently open issues?
------------------------------------------
Nope

Any relevant logs, error output, etc?
-------------------------------------
Nope

Any other comments?
-------------------
Nope

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
