### PR TITLE
Create .gitignore for new base projects

### DIFF
--- a/bin/nic.pl
+++ b/bin/nic.pl
@@ -186,6 +186,12 @@ if($makefile) {
 		}
 	}
 	untie(@lines);
+} else {
+	# New project, so create .gitignore
+	my $gitignore = "$dirname/.gitignore";
+	open my $fileHandle, ">>", $gitignore or die "Failed to create $gitignore\n";
+	print $fileHandle ".theos/\npackages/\n";
+	close $fileHandle;
 }
 print "Done.",$/;
 

--- a/bin/nic.pl
+++ b/bin/nic.pl
@@ -189,7 +189,7 @@ if($makefile) {
 } else {
 	# New project, so create .gitignore
 	my $gitignore = "$dirname/.gitignore";
-	open my $fileHandle, ">>", $gitignore or die "Failed to create $gitignore\n";
+	open my $fileHandle, ">>", $gitignore or exitWithError("Failed to create $gitignore.");
 	print $fileHandle ".theos/\npackages/\n";
 	close $fileHandle;
 }

--- a/bin/nic.pl
+++ b/bin/nic.pl
@@ -190,7 +190,7 @@ if($makefile) {
 	# New project, so create .gitignore
 	my $gitignore = "$dirname/.gitignore";
 	open my $fileHandle, ">>", $gitignore or exitWithError("Failed to create $gitignore.");
-	print $fileHandle ".theos/\npackages/\n";
+	print $fileHandle ".theos/\npackages/\n.DS_Store\n";
 	close $fileHandle;
 }
 print "Done.",$/;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
The NIC will now create a gitignore containing ".theos/" and "packages/" if a new base project (i.e., not a subproject) is created.

Does this close any currently open issues?
------------------------------------------
Resolves #2 

Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
Nope.

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL)

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
