### PR TITLE
Strip invalid chars from proj name and use that string where applicable

### DIFF
--- a/bin/nic.pl
+++ b/bin/nic.pl
@@ -101,8 +101,8 @@ promptIfMissing(\$project_name, undef, "Project Name (required)");
 exitWithError("I can't live without a project name! Aieeee!") if !$project_name;
 $clean_project_name = cleanProjectName($project_name);
 
-$package_name = $package_prefix.".".packageNameIze($project_name) if $CONFIG{'skip_package_name'};
-promptIfMissing(\$package_name, $package_prefix.".".packageNameIze($project_name), "Package Name") unless $NIC->variableIgnored("PACKAGENAME");
+$package_name = $package_prefix.".".lc($clean_project_name) if $CONFIG{'skip_package_name'};
+promptIfMissing(\$package_name, $package_prefix.".".lc($clean_project_name), "Package Name") unless $NIC->variableIgnored("PACKAGENAME");
 
 promptIfMissing(\$username, getUserName(), "Author/Maintainer Name") unless $NIC->variableIgnored("USER");
 
@@ -289,17 +289,9 @@ sub getTemplates {
 	return sort { $a->name cmp $b->name } @templates;
 }
 
-sub packageNameIze {
-	my $name = shift;
-	$name =~ s/ //g;
-	$name =~ s/[^\w\+-.]//g;
-	return lc($name);
-}
-
 sub cleanProjectName {
 	my $name = shift;
-	$name =~ s/ //g;
-	$name =~ s/\W//g;
+	$name =~ s/[^a-zA-Z0-9+-.]//g;
 	return $name;
 }
 

--- a/bin/nic.pl
+++ b/bin/nic.pl
@@ -291,7 +291,7 @@ sub getTemplates {
 
 sub cleanProjectName {
 	my $name = shift;
-	$name =~ s/[^a-zA-Z0-9+-.]//g;
+	$name =~ s/[^a-zA-Z0-9+.-]//g;
 	return $name;
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
The NIC will now strip characters that are not alphanum or "+", "-", "." from the project name provided by the user and use that name where necessary (i.e., as the project directory name, as the `Package:` field of the control file, and as the `*_NAME` field in the Makefile).

Does this close any currently open issues?
------------------------------------------
Resolves #3

Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
For a project named: "this    1_-- is a.!/ ,test\+"

The NIC made:
- this1--isa.,test+/
- control:
```
Package: com.yourcompany.this1--isa.,test+
Name: this       1_-- is a.!/ ,test\+
Version: 0.0.1
Architecture: iphoneos-arm
Description: An awesome tool of some sort!!
Maintainer: lightmann
Author: lightmann
Section: System
Tag: role::hacker
```
- Makefile:
```
TARGET := iphone:clang:latest:7.0

include $(THEOS)/makefiles/common.mk

TOOL_NAME = this1--isa.,test+

this1--isa.,test+_FILES = main.m
this1--isa.,test+_CFLAGS = -fobjc-arc
this1--isa.,test+_CODESIGN_FLAGS = -Sentitlements.plist
this1--isa.,test+_INSTALL_PATH = /usr/local/bin

include $(THEOS_MAKE_PATH)/tool.mk
```

which compiled successfully:
```
> Making all for tool this1--isa.,test+…
==> Compiling main.m (armv7)…
==> Compiling main.m (arm64e)…
==> Compiling main.m (arm64)…
==> Linking tool this1--isa.,test+ (arm64)…
==> Generating debug symbols for this1--isa.,test+…
==> Linking tool this1--isa.,test+ (arm64e)…
==> Generating debug symbols for this1--isa.,test+…
==> Linking tool this1--isa.,test+ (armv7)…
==> Generating debug symbols for this1--isa.,test+…
==> Merging tool this1--isa.,test+…
==> Signing this1--isa.,test+…
> Making stage for tool this1--isa.,test+…
dm.pl: building package `com.yourcompany.this1--isa.,test+:iphoneos-arm' in `./packages/com.yourcompany.this1--isa.,test+_0.0.1-1+debug_iphoneos-arm.deb'
```

Note: I got the alphanum + "+-." from [dm.pl](https://github.com/theos/dm.pl/blob/4699b543fdb9d3ebacde0b23db38322d27f20974/dm.pl#L81). If there is a different regex you guys want to use, just let me know and I can change what's removed here. 

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL)

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
