### PR TITLE
[nic.pl] Strip whitespace in .nicrc keys and values

### DIFF
--- a/bin/nic.pl
+++ b/bin/nic.pl
@@ -313,15 +313,22 @@ sub getHomeDir {
 }
 
 sub loadConfig {
-	open(my $cfh, "<", getHomeDir()."/.nicrc") or return;
-	while(<$cfh>) {
-		if(/^(.+?)\s*=\s*\"(.*)\"$/) {
-			my $key = $1;
-			my $value = $2;
-			$CONFIG{$key} = $value;
-		}
-	}
+    open(my $cfh, "<", getHomeDir()."/.nicrc") or return;
+    while(<$cfh>) {
+        # Remove leading and trailing whitespace
+        s/^\s+|\s+$//g;
+        if (/^(.+?)\s*=\s*"(.*)"$/) {
+            my $key = $1;
+            my $value = $2;
+            # Remove leading and trailing whitespace from key and value
+            $key =~ s/^\s+|\s+$//g;
+            $value =~ s/^\s+|\s+$//g;
+            $CONFIG{$key} = $value;
+        }
+    }
+    close($cfh);
 }
+
 
 sub nicPrompt {
 	# Do we want to import these variables into the NIC automatically? In the format name.VARIABLE?

--- a/bin/nic.pl
+++ b/bin/nic.pl
@@ -313,22 +313,17 @@ sub getHomeDir {
 }
 
 sub loadConfig {
-    open(my $cfh, "<", getHomeDir()."/.nicrc") or return;
-    while(<$cfh>) {
-        # Remove leading and trailing whitespace
-        s/^\s+|\s+$//g;
-        if (/^(.+?)\s*=\s*"(.*)"$/) {
-            my $key = $1;
-            my $value = $2;
-            # Remove leading and trailing whitespace from key and value
-            $key =~ s/^\s+|\s+$//g;
-            $value =~ s/^\s+|\s+$//g;
-            $CONFIG{$key} = $value;
-        }
-    }
-    close($cfh);
+	open(my $cfh, "<", getHomeDir()."/.nicrc") or return;
+	while(<$cfh>) {
+		if (/^\s*(.+?)\s*=\s*"(.*)"$/) {
+			my $key = $1;
+			my $value = $2;
+			$value =~ s/^\s+|\s+$//g;
+			$CONFIG{$key} = $value;
+		}
+	}
+	close($cfh);
 }
-
 
 sub nicPrompt {
 	# Do we want to import these variables into the NIC automatically? In the format name.VARIABLE?

--- a/bin/nic.pl
+++ b/bin/nic.pl
@@ -315,10 +315,11 @@ sub getHomeDir {
 sub loadConfig {
 	open(my $cfh, "<", getHomeDir()."/.nicrc") or return;
 	while(<$cfh>) {
-		if (/^\s*(.+?)\s*=\s*"(.*)"$/) {
+		# Grab config key-value pairs
+		# Match irrespective of leading whitespace
+		if(/^\s*(.+?)\s*=\s*\"(.*)\"$/) {
 			my $key = $1;
 			my $value = $2;
-			$value =~ s/^\s+|\s+$//g;
 			$CONFIG{$key} = $value;
 		}
 	}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes an issue where values are ignored if a user accidentally adds a whitespace at the beginning of a line in .nanorc

Where has this been tested?
---------------------------
**Operating System:** macOS Sonoma