### PR TITLE
Removed forced use of lowercase for project directory name

### DIFF
--- a/bin/nic.pl
+++ b/bin/nic.pl
@@ -101,12 +101,12 @@ promptIfMissing(\$project_name, undef, "Project Name (required)");
 exitWithError("I can't live without a project name! Aieeee!") if !$project_name;
 $clean_project_name = cleanProjectName($project_name);
 
-$package_name = $package_prefix.".".lc($clean_project_name) if $CONFIG{'skip_package_name'};
-promptIfMissing(\$package_name, $package_prefix.".".lc($clean_project_name), "Package Name") unless $NIC->variableIgnored("PACKAGENAME");
+$package_name = $package_prefix.".".$clean_project_name if $CONFIG{'skip_package_name'};
+promptIfMissing(\$package_name, $package_prefix.".".$clean_project_name, "Package Name") unless $NIC->variableIgnored("PACKAGENAME");
 
 promptIfMissing(\$username, getUserName(), "Author/Maintainer Name") unless $NIC->variableIgnored("USER");
 
-my $directory = lc($clean_project_name);
+my $directory = $clean_project_name;
 if(-d $directory) {
 	my $response;
 	promptIfMissing(\$response, "N", "There's already something in $directory. Continue");
@@ -156,8 +156,8 @@ if($CONFIG{'link_theos'} != 0 && !$NIC->variableIgnored("THEOS")) {
 # Execute control script.
 $NIC->exec or exitWithError("Failed to build template '".$NIC->name."'.");
 
-print "Instantiating ".$NIC->name." in ".lc($clean_project_name)."/...",$/;
-my $dirname = lc($clean_project_name);
+print "Instantiating ".$NIC->name." in ".$clean_project_name."/...",$/;
+my $dirname = $clean_project_name;
 $NIC->build($dirname);
 chdir($cwd);
 

--- a/bin/nic.pl
+++ b/bin/nic.pl
@@ -101,8 +101,8 @@ promptIfMissing(\$project_name, undef, "Project Name (required)");
 exitWithError("I can't live without a project name! Aieeee!") if !$project_name;
 $clean_project_name = cleanProjectName($project_name);
 
-$package_name = $package_prefix.".".$clean_project_name if $CONFIG{'skip_package_name'};
-promptIfMissing(\$package_name, $package_prefix.".".$clean_project_name, "Package Name") unless $NIC->variableIgnored("PACKAGENAME");
+$package_name = $package_prefix.".".lc($clean_project_name) if $CONFIG{'skip_package_name'};
+promptIfMissing(\$package_name, $package_prefix.".".lc($clean_project_name), "Package Name") unless $NIC->variableIgnored("PACKAGENAME");
 
 promptIfMissing(\$username, getUserName(), "Author/Maintainer Name") unless $NIC->variableIgnored("USER");
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
* Removes the use of `lc()` around `$clean_project_name`, i.e the directory where the template will be created. If a user chooses to uppercase their project directory name, without this change `nic.pl` disregards that and lowercases the entire name, which most likely isn't what they would expect. If they want to add capital letters to their project name, they should be able to do so without later on having to rename the project manually. If they don't want to, then they'll probably won't in the first place, therefore `nic.pl` shouldn't lowercase it for them. I don't see why this is needed in the code, I don't think it breaks anything, so removing it in my opinion is a good idea, otherwise it's just forced and might be annoying for some users.

Does this close any currently open issues?
------------------------------------------
*

Any relevant logs, error output, etc?
-------------------------------------
*
Any other comments?
-------------------
*
Where has this been tested?
---------------------------
  **Operating System:** Ubuntu 22.04

**Platform:** WSL 2

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
