### PR TITLE
Fix buffering issue in nic

### DIFF
--- a/bin/nic.pl
+++ b/bin/nic.pl
@@ -207,6 +207,7 @@ sub promptIfMissing {
 	} else {
 		print $::savedStdout $prompt, ": ";
 	}
+	$::savedStdout->flush();
 
 	$| = 1; $_ = <STDIN>;
 	chomp;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Without this fix, prompt printed to `$::savedStdout` is buffered when stdout is a pipe. The subsequent `$| = 1` clause does not help because it happens only after we print.

Does this close any currently open issues?
------------------------------------------
No.


Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** Linux (NixOS)

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
